### PR TITLE
[WIP]validator修正

### DIFF
--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -101,6 +101,8 @@ module JSON
         end
       end
 
+      base_schema = JSON::Schema.new(base_schema, schema_uri, @options[:version])
+
       if @options[:list]
         base_schema.to_array_schema
       else

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -90,12 +90,12 @@ module JSON
           if !base_schema.has_key?(f)
             raise JSON::Schema::SchemaError.new("Invalid fragment resolution for :fragment option")
           end
-          base_schema = JSON::Schema.new(base_schema[f],schema_uri,@options[:version])
+          base_schema = base_schema[f]
         elsif base_schema.is_a?(Array)
           if base_schema[f.to_i].nil?
             raise JSON::Schema::SchemaError.new("Invalid fragment resolution for :fragment option")
           end
-          base_schema = JSON::Schema.new(base_schema[f.to_i],schema_uri,@options[:version])
+          base_schema = base_schema[f.to_i]
         else
           raise JSON::Schema::SchemaError.new("Invalid schema encountered when resolving :fragment option")
         end
@@ -103,6 +103,8 @@ module JSON
 
       if base_schema.is_a?(Hash)
         base_schema = JSON::Schema.new(base_schema, schema_uri, @options[:version])
+      elsif base_schema.is_a?(Array)
+        raise JSON::Schema::SchemaError.new("Invalid schema encountered when resolving :fragment option")
       end
 
       if @options[:list]

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -101,7 +101,9 @@ module JSON
         end
       end
 
-      base_schema = JSON::Schema.new(base_schema, schema_uri, @options[:version])
+      if base_schema.is_a?(Hash)
+        base_schema = JSON::Schema.new(base_schema, schema_uri, @options[:version])
+      end
 
       if @options[:list]
         base_schema.to_array_schema

--- a/lib/json-schema/validator.rb
+++ b/lib/json-schema/validator.rb
@@ -101,10 +101,8 @@ module JSON
         end
       end
 
-      if base_schema.is_a?(Hash)
+      if !base_schema.is_a?(JSON::Schema)
         base_schema = JSON::Schema.new(base_schema, schema_uri, @options[:version])
-      elsif base_schema.is_a?(Array)
-        raise JSON::Schema::SchemaError.new("Invalid schema encountered when resolving :fragment option")
       end
 
       if @options[:list]

--- a/test/fragment_validation_with_ref_test.rb
+++ b/test/fragment_validation_with_ref_test.rb
@@ -27,8 +27,47 @@ class FragmentValidationWithRefTest < Minitest::Test
     }
   end
 
+  def whole_schema_with_array
+    {
+      "$schema" => "http://json-schema.org/draft-04/schema#",
+      "type" => "object",
+      "definitions" => {
+        "post" => {
+          "links"=> [{
+            "type" => "object",
+            "properties" => {
+              "content" => {
+                "type" => "string"
+              },
+              "author" => {
+                "type" => "string"
+              }
+            }
+          },
+          {
+            "type" => "object",
+            "properties" => {
+              "content" => {
+                  "type" => "string"
+              },
+              "author" => {
+                  "type" => "integer"
+              }
+            }
+          }]
+        }
+      }
+    }
+
+  end
+
   def test_validation_of_fragment
     data = [{"content" => "ohai", "author" => "Bob"}]
     assert_valid whole_schema, data, :fragment => "#/definitions/posts"
+  end
+
+  def test_validation_of_fragment_with_array
+    data = {"content" => "ohai", "author" => 1}
+    assert_valid whole_schema_with_array, data, :fragment => "#/definitions/post/links/1/"
   end
 end


### PR DESCRIPTION
## todo
- [x] validator修正
- [x] test追加
## やりたいこと

ruby-json-schema/json-schema の現バージョンでは

```
JSON::Validator.validate!(schema, data, fragment: '#/definitions/tip/links/0/targetSchema/')
```

のように `fragment` に '/links/0/' 等の表記があるとエラーが出てしまう。
内部のコードを見るとgemのロジックに問題があった為に発生していました。
そのため、コードを修正し使用可能にする為に作業を行う。
## 見てほしいところ

Gemを触るのが初めてで作法がわかっていません。
実装方法でおかしなところがないか、テストが正しく書けているかを見ていただきたいです。
## その他

本家のGemにマージされ次第本Gemの使用はやめる
